### PR TITLE
Make dill a required dependency for now (used in frontend for event handlers in PyScript.)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,9 @@ authors = [
     { name = "Andrea Giammarchi", email = "andrea.giammarchi@gmail.com" }
 ]
 requires-python = ">=3.14"
-dependencies = []
+dependencies = [
+    "dill>=0.4.0",
+]
 
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -36,6 +36,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dill"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/80/630b4b88364e9a8c8c5797f4602d0f76ef820909ee32f0bacb9f90654042/dill-0.4.0.tar.gz", hash = "sha256:0633f1d2df477324f53a895b02c901fb961bdbf65a17122586ea7019292cbcf0", size = 186976 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/3d/9373ad9c56321fdab5b41197068e1d8c25883b3fea29dd361f9b55116869/dill-0.4.0-py3-none-any.whl", hash = "sha256:44f54bf6412c2c8464c14e8243eb163690a9800dbe2c367330883b19c7561049", size = 119668 },
+]
+
+[[package]]
 name = "hatchling"
 version = "1.27.0"
 source = { registry = "https://pypi.org/simple" }
@@ -123,6 +132,9 @@ wheels = [
 name = "tdom"
 version = "0.1.0"
 source = { editable = "." }
+dependencies = [
+    { name = "dill" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -132,6 +144,7 @@ dev = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "dill", specifier = ">=0.4.0" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Fix #18 - Dill as a dependency.